### PR TITLE
Adding logic for generating a static html of tested elements

### DIFF
--- a/src/main/java/info/seleniumcucumber/methods/SelectElementByType.java
+++ b/src/main/java/info/seleniumcucumber/methods/SelectElementByType.java
@@ -1,9 +1,15 @@
 package info.seleniumcucumber.methods;
 
 import env.DriverUtil;
+import org.apache.commons.io.FileUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.WebDriverWait;
+
+import javax.swing.text.html.HTMLDocument;
+import java.io.*;
+import java.util.List;
 
 public class SelectElementByType 
 {
@@ -20,11 +26,49 @@ public class SelectElementByType
 	 */
 	public By getelementbytype(String type,String access_name)
 	{
+		File staticHtml = new File("staticHtml.html");
+		if (!staticHtml.exists()) {
+			try {
+				FileUtils.touch(staticHtml);
+			}catch (IOException e){
+				System.out.println("Caught exception during file creation...");
+			}
+		}
+		//List<WebElement> list = driver.findElements(By.xpath("//*[@id='row']/td/b"));
+		System.out.println(type + " " + access_name);
+
+		FileWriter fw = null;
+		BufferedWriter bw = null;
+		PrintWriter out = null;
+		try {
+			fw = new FileWriter("staticHtml.html", true);
+			bw = new BufferedWriter(fw);
+			out = new PrintWriter(bw);
+
+		}catch (IOException f) {
+			System.out.println("Caught Exception during write to file");
+		}
+
 		switch(type)
 		{
-			case "id" : return By.id(access_name);
+			case "id" :
+					WebElement idElement = driver.findElement(By.id(access_name));
+					WebElement parent = idElement.findElement(By.xpath(".."));
+					//document.getElementById('username').parent.getElementsByTagName('label')[0];
+					WebElement label = parent.findElement(By.tagName("label"));
+					out.print(label.getText());
+					out.print("<br/>");
+					out.println(idElement.getAttribute("outerHTML"));
+					out.print("<br/>");
+					out.close();
+				return By.id(access_name);
 			case "name" : return By.name(access_name);
-			case "class" : return By.className(access_name);
+			case "class" :
+					WebElement classElement = driver.findElement(By.className(access_name));
+					out.println(classElement.getAttribute("outerHTML"));
+					out.println();
+					out.close();
+				return By.className(access_name);
 			case "xpath" : return By.xpath(access_name);
 			case "css" : return By.cssSelector(access_name);
 			case "linkText" : return By.linkText(access_name);


### PR DESCRIPTION
The purpose of this logic is to an html page containg all elements that have been tested by the framework. In this example, the username and password fields were tested a couple of times as well as the login button. The staticHtml.html is generated at the root of the directory and would look like this:
<img width="692" alt="screen shot 2018-11-29 at 10 44 11 am" src="https://user-images.githubusercontent.com/45013929/49233433-03576980-f3c4-11e8-9a50-26bab35e1a52.png">
